### PR TITLE
[FEATURE] Add new endpoints

### DIFF
--- a/backend/controllers/caas_next_refid.rb
+++ b/backend/controllers/caas_next_refid.rb
@@ -20,7 +20,7 @@ class ArchivesSpaceService < Sinatra::Base
     json_response(:resource_id => params[:resource_id], :next_refid => incremented_id)
   end
 
-  Endpoint.get('/plugins/caas_next_refid/:resource_id')
+  Endpoint.get('/plugins/caas_next_refid/resources/:resource_id')
     .description("Get the next_refid for a specific resource")
     .params(["resource_id", Integer, :resource_id, :required => "true"])
     .permissions([:administer_system])
@@ -37,7 +37,7 @@ class ArchivesSpaceService < Sinatra::Base
     end
   end
 
-  Endpoint.post('/plugins/caas_next_refid/:resource_id')
+  Endpoint.post('/plugins/caas_next_refid/resources/:resource_id')
     .description("Manually set next ref_id for provided resource")
     .params(["resource_id", Integer, :resource_id, :required => "true"],
             ["next_refid", Integer, :next_refid, :required => "true"])

--- a/backend/controllers/caas_next_refid.rb
+++ b/backend/controllers/caas_next_refid.rb
@@ -20,13 +20,14 @@ class ArchivesSpaceService < Sinatra::Base
     json_response(:resource_id => params[:resource_id], :next_refid => incremented_id)
   end
 
-  Endpoint.get('/plugins/caas_next_refid/resources/:resource_id')
+  Endpoint.get('/plugins/caas_next_refid/find_by_uri')
     .description("Get the next_refid for a specific resource")
-    .params(["resource_id", Integer, :resource_id, :required => "true"])
+    .params(["resource_uri", String, "The uri of the desired resource.", :required => "true"])
     .permissions([:administer_system])
     .returns([200, (:caas_next_refid)]) \
   do
-    current_refid = CaasAspaceRefid.find(resource_id: params[:resource_id])
+    resource_id = JSONModel.parse_reference(params[:resource_uri])&.fetch(:id)
+    current_refid = CaasAspaceRefid.find(resource_id: resource_id)
 
     if current_refid
       json = CaasAspaceRefid.to_jsonmodel(current_refid.id)
@@ -37,16 +38,17 @@ class ArchivesSpaceService < Sinatra::Base
     end
   end
 
-  Endpoint.post('/plugins/caas_next_refid/resources/:resource_id')
+  Endpoint.post('/plugins/caas_next_refid/set_by_uri')
     .description("Manually set next ref_id for provided resource")
-    .params(["resource_id", Integer, :resource_id, :required => "true"],
+    .params(["resource_uri", String, "The uri of the desired resource.", :required => "true"],
             ["next_refid", Integer, :next_refid, :required => "true"])
     .permissions([:administer_system])
     .returns([200, :updated]) \
   do
-    current_refid = CaasAspaceRefid.find(resource_id: params[:resource_id])
+    resource_id = JSONModel.parse_reference(params[:resource_uri])&.fetch(:id)
+    current_refid = CaasAspaceRefid.find(resource_id: resource_id)
     new_refid = params[:next_refid]
-    if !current_refid.nil?
+    if current_refid
       if current_refid.next_refid >= params[:next_refid]
         raise BadParamsException.new(next_refid: "Cannot set a next_refid that is less than or equal to the current refid: #{current_refid.next_refid}")
       end
@@ -54,10 +56,10 @@ class ArchivesSpaceService < Sinatra::Base
       json = CaasAspaceRefid.to_jsonmodel(new_refid_record.id)
       handle_update(CaasAspaceRefid, current_refid.id, json)
     else
-      CaasAspaceRefid.create_from_json(JSONModel(:caas_next_refid).from_hash({:resource_id => params[:resource_id],
+      CaasAspaceRefid.create_from_json(JSONModel(:caas_next_refid).from_hash({:resource_id => resource_id,
                                                                               :next_refid => new_refid }))
     end
 
-    json_response(:resource_id => params[:resource_id], :next_refid => new_refid)
+    json_response(:resource_uri => params[:resource_uri], :next_refid => new_refid)
   end
 end

--- a/backend/spec/controller_caas_next_refid_spec.rb
+++ b/backend/spec/controller_caas_next_refid_spec.rb
@@ -1,24 +1,136 @@
 require 'spec_helper'
 
 describe 'CAAS ref id plugin' do
-  context 'when no resource_id is provided' do
-    it 'throws an error' do
-      post '/plugins/caas_next_refid', params = { }
+  describe 'POST /plugins/caas_next_refid' do
+    context 'when no resource_id is provided' do
+      it 'throws an error' do
+        post '/plugins/caas_next_refid', params = { }
 
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(400)
-      expect(last_response.body).to include('error')
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to include('error')
+      end
+    end
+
+    context 'when a resource_id is provided' do
+      let(:resource) { create_resource }
+
+      it 'creates a next_refid' do
+        post '/plugins/caas_next_refid', params = { "resource_id" => resource.id}
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+      end
     end
   end
 
-  context 'when a resource_id is provided' do
-    let(:resource) { create_resource }
+  describe 'GET /plugins/caas_next_refid/:rid' do
+    context 'when a bad resource_id is provided' do
+      let(:rid) { rand(100) }
 
-    it 'creates a next_refid' do
-      post '/plugins/caas_next_refid', params = { "resource_id" => resource.id}
+      it 'throws an error' do
+        get "/plugins/caas_next_refid/#{rid}"
 
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to include('CaasAspaceRefid was not found')
+      end
+    end
+
+    context 'when an existing resource_id is provided' do
+      let(:resource) { create_resource }
+
+      before do
+        post '/plugins/caas_next_refid', params = { 'resource_id' => resource.id}
+      end
+
+      it 'returns the next_refid' do
+        get "/plugins/caas_next_refid/#{resource.id}"
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to match(/"next_refid":1/)
+      end
+
+
+      context 'when a user without administer system permissions' do
+        before do
+          make_test_user('archivist')
+        end
+
+        it 'denies access' do
+          as_test_user('archivist') do
+            get "/plugins/caas_next_refid/#{resource.id}"
+
+            expect(last_response).not_to be_ok
+            expect(last_response.status).to eq(403)
+            expect(last_response.body).to match(/Access denied/)
+          end
+        end
+      end
+
+    end
+  end
+
+  describe 'POST /plugins/caas_next_refid/:rid' do
+    context 'when a bad resource_id is provided' do
+      let(:rid) { rand(100) }
+
+      it 'throws an error' do
+        post "/plugins/caas_next_refid/#{rid}", params = { 'next_refid' => 300}
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+        expect(last_response.body).to match(/Database integrity constraint conflict/)
+      end
+    end
+
+    context 'when an existing resource_id is provided' do
+      let(:resource) { create_resource }
+
+      before do
+        post '/plugins/caas_next_refid/', params = { 'resource_id' => resource.id}
+      end
+
+      it 'updates the next_refid to the provided value' do
+        post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 300}
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to match(/"next_refid":300/)
+      end
+
+      context 'when a next_refid less than the current ref_id is provided' do
+        before do
+          model = instance_double(CaasAspaceRefid)
+          allow(CaasAspaceRefid).to receive(:find).with(resource_id: resource.id).and_return(model)
+          allow(model).to receive(:next_refid).and_return(300)
+        end
+
+        it 'throws an error' do
+          post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 1 }
+
+          expect(last_response).not_to be_ok
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to include('Cannot set a next_refid that is less than or equal to the current refid')
+        end
+      end
+
+      context 'when a user without administer system permissions' do
+        before do
+          make_test_user('archivist')
+        end
+
+        it 'denies access' do
+          as_test_user('archivist') do
+            post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 300}
+
+            expect(last_response).not_to be_ok
+            expect(last_response.status).to eq(403)
+            expect(last_response.body).to match(/Access denied/)
+          end
+        end
+      end
     end
   end
 end

--- a/backend/spec/controller_caas_next_refid_spec.rb
+++ b/backend/spec/controller_caas_next_refid_spec.rb
@@ -24,12 +24,12 @@ describe 'CAAS ref id plugin' do
     end
   end
 
-  describe 'GET /plugins/caas_next_refid/:rid' do
+  describe 'GET /plugins/caas_next_refid/resources/:rid' do
     context 'when a bad resource_id is provided' do
       let(:rid) { rand(100) }
 
       it 'throws an error' do
-        get "/plugins/caas_next_refid/#{rid}"
+        get "/plugins/caas_next_refid/resources/#{rid}"
 
         expect(last_response).not_to be_ok
         expect(last_response.status).to eq(404)
@@ -45,7 +45,7 @@ describe 'CAAS ref id plugin' do
       end
 
       it 'returns the next_refid' do
-        get "/plugins/caas_next_refid/#{resource.id}"
+        get "/plugins/caas_next_refid/resources/#{resource.id}"
 
         expect(last_response).to be_ok
         expect(last_response.status).to eq(200)
@@ -60,7 +60,7 @@ describe 'CAAS ref id plugin' do
 
         it 'denies access' do
           as_test_user('archivist') do
-            get "/plugins/caas_next_refid/#{resource.id}"
+            get "/plugins/caas_next_refid/resources/#{resource.id}"
 
             expect(last_response).not_to be_ok
             expect(last_response.status).to eq(403)
@@ -72,12 +72,12 @@ describe 'CAAS ref id plugin' do
     end
   end
 
-  describe 'POST /plugins/caas_next_refid/:rid' do
+  describe 'POST /plugins/caas_next_refid/resources/:rid' do
     context 'when a bad resource_id is provided' do
       let(:rid) { rand(100) }
 
       it 'throws an error' do
-        post "/plugins/caas_next_refid/#{rid}", params = { 'next_refid' => 300}
+        post "/plugins/caas_next_refid/resources/#{rid}", params = { 'next_refid' => 300}
 
         expect(last_response).not_to be_ok
         expect(last_response.status).to eq(400)
@@ -93,7 +93,7 @@ describe 'CAAS ref id plugin' do
       end
 
       it 'updates the next_refid to the provided value' do
-        post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 300}
+        post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 300}
 
         expect(last_response).to be_ok
         expect(last_response.status).to eq(200)
@@ -108,7 +108,7 @@ describe 'CAAS ref id plugin' do
         end
 
         it 'throws an error' do
-          post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 1 }
+          post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 1 }
 
           expect(last_response).not_to be_ok
           expect(last_response.status).to eq(400)
@@ -123,7 +123,7 @@ describe 'CAAS ref id plugin' do
 
         it 'denies access' do
           as_test_user('archivist') do
-            post "/plugins/caas_next_refid/#{resource.id}", params = { 'next_refid' => 300}
+            post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 300}
 
             expect(last_response).not_to be_ok
             expect(last_response.status).to eq(403)

--- a/backend/spec/controller_caas_next_refid_spec.rb
+++ b/backend/spec/controller_caas_next_refid_spec.rb
@@ -24,12 +24,12 @@ describe 'CAAS ref id plugin' do
     end
   end
 
-  describe 'GET /plugins/caas_next_refid/resources/:rid' do
-    context 'when a bad resource_id is provided' do
-      let(:rid) { rand(100) }
+  describe 'GET /plugins/caas_next_refid/find_by_uri' do
+    context 'when a bad resource_uri is provided' do
+      let(:resource_uri) { "/repositories/2/resources/#{rand(100)}" }
 
       it 'throws an error' do
-        get "/plugins/caas_next_refid/resources/#{rid}"
+        get "/plugins/caas_next_refid/find_by_uri?resource_uri=#{resource_uri}"
 
         expect(last_response).not_to be_ok
         expect(last_response.status).to eq(404)
@@ -37,15 +37,15 @@ describe 'CAAS ref id plugin' do
       end
     end
 
-    context 'when an existing resource_id is provided' do
+    context 'when an existing resource_uri is provided' do
       let(:resource) { create_resource }
 
       before do
-        post '/plugins/caas_next_refid', params = { 'resource_id' => resource.id}
+        post '/plugins/caas_next_refid', params = { resource_id: resource.id}
       end
 
       it 'returns the next_refid' do
-        get "/plugins/caas_next_refid/resources/#{resource.id}"
+        get '/plugins/caas_next_refid/find_by_uri', params = { resource_uri: resource.uri }
 
         expect(last_response).to be_ok
         expect(last_response.status).to eq(200)
@@ -60,7 +60,7 @@ describe 'CAAS ref id plugin' do
 
         it 'denies access' do
           as_test_user('archivist') do
-            get "/plugins/caas_next_refid/resources/#{resource.id}"
+            get '/plugins/caas_next_refid/find_by_uri', params = { resource_uri: resource.uri }
 
             expect(last_response).not_to be_ok
             expect(last_response.status).to eq(403)
@@ -72,12 +72,13 @@ describe 'CAAS ref id plugin' do
     end
   end
 
-  describe 'POST /plugins/caas_next_refid/resources/:rid' do
-    context 'when a bad resource_id is provided' do
-      let(:rid) { rand(100) }
+  describe 'POST /plugins/caas_next_refid/set_by_uri' do
+    context 'when a bad resource_uri is provided' do
+      let(:resource_uri) { "/repositories/2/resources/#{rand(100)}" }
 
       it 'throws an error' do
-        post "/plugins/caas_next_refid/resources/#{rid}", params = { 'next_refid' => 300}
+        post '/plugins/caas_next_refid/set_by_uri', params = { resource_uri: resource_uri,
+                                                               next_refid: 300 }
 
         expect(last_response).not_to be_ok
         expect(last_response.status).to eq(400)
@@ -85,15 +86,16 @@ describe 'CAAS ref id plugin' do
       end
     end
 
-    context 'when an existing resource_id is provided' do
+    context 'when an existing resource_uri is provided' do
       let(:resource) { create_resource }
 
       before do
-        post '/plugins/caas_next_refid/', params = { 'resource_id' => resource.id}
+        post '/plugins/caas_next_refid/set_by_uri', params = { resource_uri: resource.uri}
       end
 
       it 'updates the next_refid to the provided value' do
-        post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 300}
+        post "/plugins/caas_next_refid/set_by_uri", params = { resource_uri: resource.uri,
+                                                               next_refid: 300}
 
         expect(last_response).to be_ok
         expect(last_response.status).to eq(200)
@@ -108,7 +110,8 @@ describe 'CAAS ref id plugin' do
         end
 
         it 'throws an error' do
-          post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 1 }
+          post "/plugins/caas_next_refid/set_by_uri", params = { resource_uri: resource.uri,
+                                                                 next_refid: 1 }
 
           expect(last_response).not_to be_ok
           expect(last_response.status).to eq(400)
@@ -123,7 +126,8 @@ describe 'CAAS ref id plugin' do
 
         it 'denies access' do
           as_test_user('archivist') do
-            post "/plugins/caas_next_refid/resources/#{resource.id}", params = { 'next_refid' => 300}
+            post '/plugins/caas_next_refid/set_by_uri', params = { resource_uri: resource.uri,
+                                                                   next_refid: 300}
 
             expect(last_response).not_to be_ok
             expect(last_response.status).to eq(403)


### PR DESCRIPTION
## Description
Adds two new endpoints restricted to system administrators:

1. `GET /plugins/caas_next_refid/:resource_id` - returns the next_refid for an existing resource.  Required parameter `:resource_id`: the id of the resource record.
3. `POST /plugins/caas_next_refid/:resource_id?next_refid=:next_refid` - Updates the next_refid for the resource.  Required parameters `:resource_id`: the id of the resource record and `:next_refid`: the integer to set the next_refid to (must be greater than the currently set ref_id).

## Related GitHub Issue
Closes #16 

## Testing
New automated tests added.

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
⚠️ I have created #18 to address a more wholistic approach to adding API documentation for this plugin
A MVP example of this proposed documentation is available in my fork of this plugin: https://lorawoodford.github.io/caas_aspace_refid/
- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?
⚠️ I have created #18 to address a more wholistic approach to adding API documentation for this plugin
A MVP example of this proposed documentation is available in my fork of this plugin: https://lorawoodford.github.io/caas_aspace_refid/