### PR TITLE
[FEATURE] Create OpenAPI documentation for plugin endpoints #18

### DIFF
--- a/.github/workflows/api_lint.yml
+++ b/.github/workflows/api_lint.yml
@@ -1,0 +1,25 @@
+name: API linting
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  push:
+    paths:
+      - 'docs/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up node
+        uses: actions/setup-node@v4
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+      - name: Run linting
+        run: |
+          redocly lint docs/openapi.yml --format=github-actions

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,29 @@
+name: Build and deploy API docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build docs
+        run: |
+          npx @redocly/cli build-docs docs/openapi.yml -o index.html
+
+      - name: Deploy to GitHub Pages
+        if: github.event.repository.fork == false
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          force_orphan: true
+          exclude_assets: '.github,backend,frontend,migrations,schemas,.rubocop.yml'

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,131 @@
+openapi: 3.1.0
+info:
+  title: CAAS ASpace Refid Plugin API
+  version: '0.1'
+
+servers:
+  - url: http://localhost:4567
+    description: Locally running development instance of ArchivesSpace
+  - url: http://localhost:8089
+    description: Locally running build of ArchivesSpace
+
+paths:
+  /plugins/caas_next_refid:
+    post:
+      operationId: postNextRefid
+      summary: Mint the next ref_id for provided resource
+      description: _Note_ This is the endpoint hit by the Staff UI
+      parameters:
+        - name: resource_id
+          in: query
+          description: The ID of the current resource
+          example: 1
+          required: true
+          schema:
+            type: integer
+      security:
+        - auth: []
+      responses:
+        '200': # status code
+          description: A JSON response object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaasNextRefid'
+        '400':
+          description: Bad request
+  /plugins/caas_next_refid/find_by_uri:
+    get:
+      operationId: getRefid
+      summary: Get next ref_id for provided resource
+      parameters:
+        - name: resource_uri
+          in: query
+          description: The uri of the desired resource
+          example: '/repositories/2/resources/1'
+          required: true
+          schema:
+            type: string
+      security:
+        - auth: ['administer_system']
+      responses:
+        '200': # status code
+          description: A JSON response object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaasNextRefid'
+        '400':
+          description: Bad request
+  /plugins/caas_next_refid/set_by_uri:
+    post:
+      operationId: postRefid
+      summary: Manually set next ref_id for provided resource
+      parameters:
+        - name: resource_uri
+          in: query
+          description: The uri of the desired resource
+          example: '/repositories/2/resources/1'
+          required: true
+          schema:
+            type: string
+        - name: next_refid
+          in: query
+          description: The ID of the user-supplied next_refid.  Must be greater than the current next_refid.
+          example: 1001
+          required: true
+          schema:
+            type: integer
+      security:
+        - auth: ['administer_system']
+      responses:
+        '200': # status code
+          description: A JSON response object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaasNextRefid'
+        '400':
+          description: Bad request
+
+components:
+  schemas:
+    CaasNextRefid:
+      properties:
+        lock_version:
+          type: integer
+          format: int64
+          example: 0
+        resource_id:
+          type: integer
+          format: int64
+          example: 10
+        next_refid:
+          type: integer
+          format: int64
+          example: 198772
+        create_time:
+          type: string
+          format: date-time
+          example: '2025-04-03T16:44:34Z'
+        system_mtime:
+          type: string
+          format: date-time
+          example: '2025-04-03T16:44:34Z'
+        user_mtime:
+          type: string
+          format: date-time
+          example: '2025-04-03T16:44:34Z'
+        jsonmodel_type:
+          type: string
+        uri:
+          type: string
+          format: uri
+          example: '/plugins/caas_next_refid/1'
+      type: object
+  securitySchemes:
+    auth:
+      type: apiKey
+      in: header
+      name: X-ArchivesSpace-Session
+      x-apikeyInfoFunc: app.auth


### PR DESCRIPTION
## Description
Adds [OpenAPI](https://www.openapis.org/) documentation for custom plugin endpoints, and adds two new GitHub Actions to 1) lint the documentation and 2) build and deploy that documentation to GitHub Pages with redoc.

The api documentation in `docs/openapi.yml` is pretty manual/repetitive at the moment, but can be iterated in the future when time and need allows.  But for now, it's serving it's purpose.

The initial docs won't be built until this PR is merged to main, so to serve as a visual preview I've run the process on my fork.  Here's what the generated documentation will ultimately look like: https://lorawoodford.github.io/caas_aspace_refid/

We can pretty it up with logos, additional information, etc. (see the aptly themed redoc example: https://redocly.github.io/redoc/), but, again, this is just a starting point.

## Related GitHub Issue
Closes #18 

## Testing
None, no code changes.  Linter added.

## Screenshot(s):
<img width="1496" alt="Screenshot 2025-04-04 at 10 29 01 AM" src="https://github.com/user-attachments/assets/78463c11-83ce-497a-9550-e20a20cabab1" />

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
