### PR TITLE
[FEATURE] Figure out the preferred way of adding RefIDs to Digitizati…

### DIFF
--- a/backend/model/archival_object.rb
+++ b/backend/model/archival_object.rb
@@ -18,16 +18,13 @@ rule_template = ERB.new("<%= resource['ead_id'] %>_ref<%= generate_ref_id(resour
 
 ArchivalObject.auto_generate(property: :ref_id,
                              generator: proc do |json|
-                               repo_id = RequestContext.get(:repo_id)
-                               resource = Resource.to_jsonmodel(JSONModel::JSONModel(:resource).id_for(json['resource']['ref']))
-                               rule_template.result(binding())
-                             end,
-                             only_on_create: true)
-
-ArchivalObject.auto_generate(property: :ref_id,
-                             generator: proc do |json|
-                               repo_id = RequestContext.get(:repo_id)
-                               resource = Resource.to_jsonmodel(JSONModel::JSONModel(:resource).id_for(json['resource']['ref']))
-                               rule_template.result(binding())
-                             end,
-                             only_if: proc { |json| json['caas_regenerate_ref_id'] })
+                               # handling for newly created aos and ao's with caas_regenerate_ref_id set to true
+                               if json['ref_id'].nil? || json['caas_regenerate_ref_id']
+                                 repo_id = RequestContext.get(:repo_id)
+                                 resource = Resource.to_jsonmodel(JSONModel::JSONModel(:resource).id_for(json['resource']['ref']))
+                                 rule_template.result(binding())
+                               # handling for caas_regenerate_ref_id set to false, including bulk update flow
+                               elsif json['caas_regenerate_ref_id'] === false
+                                 json[:ref_id] = ArchivalObject.to_jsonmodel(JSONModel::JSONModel(:archival_object).id_for(json['uri']))['ref_id']
+                               end
+                             end)

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -40,23 +40,44 @@ describe 'ArchivalObject model' do
         end
       end
 
-      context 'when an existing archival object is updated with caas_regenerate_ref_id set to true' do
+      context 'when an archival object exists' do
         let(:archival_object) do
-          create_archival_object({ ref_id: '123',
-                                    caas_regenerate_ref_id: true,
-                                    resource: { ref: "/repositories/2/resources/#{resource.id}" } })
+          create_archival_object({ resource: { ref: "/repositories/2/resources/#{resource.id}" } })
+        end
+        let(:ao_json) { ArchivalObject.to_jsonmodel(archival_object.id) }
+
+        context 'when that archival object is updated with caas_regenerate_ref_id set to true' do
+          let(:updated_ao) do
+            ao_json['caas_regenerate_ref_id'] = true
+            archival_object.update_from_json(ao_json)
+          end
+
+          it 'calls the caas_next_refid endpoint' do
+            updated_ao
+
+            expect(Net::HTTP).to have_received(:start)
+          end
+
+          it 'auto generates ref_id' do
+            expect(updated_ao.ref_id).to eq('my.eadid_ref40')
+          end
         end
 
-        it 'calls the caas_next_refid endpoint' do
-          archival_object
+        context 'when that archival object is updated with caas_regenerate_ref_id set to false' do
+          let(:updated_ao) do
+            ao_json['caas_regenerate_ref_id'] = false
+            archival_object.update_from_json(ao_json)
+          end
 
-          expect(Net::HTTP).to have_received(:start)
-        end
+          it 'does not call the caas_next_refid endpoint' do
+            updated_ao
 
-        it 'auto generates ref_id' do
-          archival_object.save
+            expect(Net::HTTP).not_to have_received(:start)
+          end
 
-          expect(archival_object.ref_id).to eq('my.eadid_ref40')
+          it 'retains the previous ref_id' do
+            expect(updated_ao.ref_id).to eq(ao_json['ref_id'])
+          end
         end
       end
     end
@@ -93,36 +114,46 @@ describe 'ArchivalObject model' do
         end
       end
 
-      context 'when an existing archival object is updated with caas_regenerate_ref_id set to true' do
+      context 'when an archival object exists' do
         let(:archival_object) do
-          create_archival_object({ caas_regenerate_ref_id: true,
-                                   resource: { ref: "/repositories/2/resources/#{resource.id}" } })
+          create_archival_object({ resource: { ref: "/repositories/2/resources/#{resource.id}" } })
+        end
+        let(:ao_json) { ArchivalObject.to_jsonmodel(archival_object.id) }
+
+        context 'when that archival object is updated with caas_regenerate_ref_id set to true' do
+          let(:updated_ao) do
+            ao_json['caas_regenerate_ref_id'] = true
+            archival_object.update_from_json(ao_json)
+          end
+
+          it 'calls the caas_next_refid endpoint' do
+            updated_ao
+
+            expect(Net::HTTP).to have_received(:start)
+          end
+
+          it 'auto generates ref_id' do
+            expect(updated_ao.ref_id).to start_with("my.eadid_ref#{refid_fallback}")
+          end
         end
 
-        it 'calls the caas_next_refid endpoint' do
-          archival_object
+        context 'when that archival object is updated with caas_regenerate_ref_id set to false' do
+          let(:updated_ao) do
+            ao_json['caas_regenerate_ref_id'] = false
+            archival_object.update_from_json(ao_json)
+          end
 
-          expect(Net::HTTP).to have_received(:start)
-        end
+          it 'does not call the caas_next_refid endpoint' do
+            updated_ao
 
-        it 'auto generates ref_id' do
-          expect(archival_object.ref_id).to start_with("my.eadid_ref#{refid_fallback}")
+            expect(Net::HTTP).not_to have_received(:start)
+          end
+
+          it 'retains the previous ref_id' do
+            expect(updated_ao.ref_id).to eq(ao_json['ref_id'])
+          end
         end
       end
-    end
-  end
-
-  context 'when the resource does not exist yet' do
-    let(:refid_fallback) { DateTime.now.strftime('%s')[0..-2] }
-
-    before do
-      allow(Net::HTTP).to receive(:start).and_call_original
-    end
-
-    describe '#generate_ref_id' do
-      it 'returns a unique date string' do
-         expect(generate_ref_id(nil, $repo_id)).to start_with(refid_fallback)
-       end
     end
   end
 end

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -23,6 +23,13 @@ paths:
           required: true
           schema:
             type: integer
+        - name: repo_id
+          in: query
+          description: The ID of the archival object's repository
+          example: 2
+          required: true
+          schema:
+            type: integer
       security:
         - auth: []
       responses:


### PR DESCRIPTION
…on Word Order plugin or Bulk Update Export plugin #44

## Description
Consolidates ref_id auto-generation code into one block based on the investigation described in #44 

Also fixes one minor inaccuracy in the API docs -- the required `repo_id` param was left out in the initial description.

## Related GitHub Issue
Closes #44 

## Testing
Tests updated, added, and passing.

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
