### PR TITLE
[FEATURE] Update for 4.x compatibility #49

### DIFF
--- a/.github/workflows/backend_plugin_test.yml
+++ b/.github/workflows/backend_plugin_test.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v3.3.1, v3.4.1, v3.5.1, v4.0.0]
+        archivesspace_version: [v4.0.0, v4.1.0]
 
     services:
       db:

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -10,7 +10,7 @@ jobs:
   code_scan:
     runs-on: ubuntu-latest
     env:
-      PROD_ARCHIVESSPACE_VERSION: v3.3.1
+      PROD_ARCHIVESSPACE_VERSION: v4.1.0
 
     steps:
     - name: Setup ArchivesSpace ${{ env.PROD_ARCHIVESSPACE_VERSION }}

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -13,3 +13,5 @@ on:
 jobs:
   diff:
     uses: Smithsonian/caas-aspace-services/.github/workflows/diff.yml@main
+    with:
+      prod_archivesspace_version: v4.1.0

--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v3.3.1, v4.0.0]
+        archivesspace_version: [v4.0.0, v4.1.0]
 
     services:
       db:

--- a/frontend/views/archival_objects/_form_container.html.erb
+++ b/frontend/views/archival_objects/_form_container.html.erb
@@ -2,17 +2,17 @@
 
 <h2>
   <% if @archival_object.display_string.blank? %>
-    <%= I18n.t("archival_object._singular") %>
+    <%= t("archival_object._singular") %>
   <% else %>
     <%= clean_mixed_content(@archival_object.display_string) %>
   <% end %>
-  <span class="label label-info"><%= I18n.t("archival_object._singular") %></span>
+  <span class="label label-info badge"><%= t("archival_object._singular") %></span>
 </h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
-  <%= form.hidden_input "parent", nil, {"data-base-name" => "archival_object[parent]", "class" => "hidden-parent-uri", "data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-modal-title" => I18n.t('archival_object._frontend.action.select_parent_and_position'), "data-leave-empty" => I18n.t('archival_object._frontend.action.leave_parent_empty')} %>
-  <%= form.hidden_input "resource", nil, {"data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.RESOURCE_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.RESOURCE_FACETS), "data-modal-title" => I18n.t('archival_object._frontend.action.select_resource')} %>
+  <%= form.hidden_input "parent", nil, {"data-base-name" => "archival_object[parent]", "class" => "hidden-parent-uri", "data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-modal-title" => t('archival_object._frontend.action.select_parent_and_position'), "data-leave-empty" => t('archival_object._frontend.action.leave_parent_empty')} %>
+  <%= form.hidden_input "resource", nil, {"data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.RESOURCE_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.RESOURCE_FACETS), "data-modal-title" => t('archival_object._frontend.action.select_resource')} %>
 
   <%= form.hidden_input "position" %>
 
@@ -21,20 +21,24 @@
 
   <% define_template("archival_object", jsonmodel_definition(:archival_object)) do |form| %>
     <section id="basic_information">
-      <h3>
-        <%= I18n.t("archival_object._frontend.section.basic_information") %>
+      <header class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
+        <h3 class="flex-grow-1 mb-0 border-0">
+          <%= t("archival_object._frontend.section.basic_information") %>
+        </h3>
         <%= link_to_help :topic => "archival_object_basic_information" %>
-      </h3>
+      </header>
 
       <fieldset>
         <%= render_plugin_partials("top_of_basic_information_archival_object",
                                    :form => form,
                                    :record => @archival_object) %>
 
-        <%= form.label_and_textarea("title", :required => :conditionally)%>
+        <%= form.label_and_textarea("title", :required => :conditionally, :field_opts => {
+          :class => "form-control#{AppConfig[:allow_mixed_content_title_fields] ? ' mixed-content' : ''}"
+        })%>
 
         <% if form.obj["ref_id"].blank? %>
-          <%= form.label_and_readonly "ref_id", "<em>#{I18n.t("archival_object.ref_id_auto_generation_message")}</em>" %>
+          <%= form.label_and_readonly "ref_id", "<em>#{t("archival_object.ref_id_auto_generation_message")}</em>" %>
         <% else %>
           <%= form.label_with_field "ref_id", form.hidden_input("ref_id") + "<span class='identifier-display'><span class='identifier-display-part'>#{form.obj["ref_id"]}</span></span>".html_safe %>
         <% end %>
@@ -53,12 +57,12 @@
         <%= form.label_and_textfield "external_ark_url" if AppConfig[:arks_enabled] && AppConfig[:arks_allow_external_arks] %>
         <%= form.label_and_select "level", form.possible_options_for("level", true) %>
         <%= form.label_and_textfield "other_level", :required => true %>
-        <div class="form-group">
-          <%= form.label "publish", :class => 'control-label col-sm-2' %>
-          <div class="checkbox col-sm-9">
+        <div class="form-group w-100 row">
+          <%= form.label "publish", :class => 'control-label col-sm-2 text-right' %>
+          <div class="col-sm-1 checkbox">
             <%= form.checkbox "publish", {}, user_prefs["publish"] %>
             <% if form.obj["has_unpublished_ancestor"] %>
-              <span class="help-inline"><span class="text-info"><%= I18n.t("archival_object._frontend.messages.has_unpublished_ancestor") %></span></span>
+              <span class="help-inline"><span class="text-info"><%= t("archival_object._frontend.messages.has_unpublished_ancestor") %></span></span>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## Description
Updating the archival object form to match v4.1.0 upstream forms.

## Related GitHub Issue
Closes #49 

## Testing
Existing tests passing, but did take the opportunity to bump the matrix versions for tests.  Since this is being merged into a feature branch we won't be blocked by current required checks.

## Screenshot(s):
Minor stylistic improvements, such as:
Before
<img width="450" alt="Screenshot 2025-05-30 at 4 22 09 PM" src="https://github.com/user-attachments/assets/9ca6a656-396d-44a3-9332-bc6661b9ae7b" />

After
<img width="457" alt="Screenshot 2025-05-30 at 4 25 43 PM" src="https://github.com/user-attachments/assets/7341138b-9936-4bb4-a291-eabf9fdc164e" />

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Skipping, since this isn't a merge into main.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
