### PR TITLE
[FEATURE] Make work with "Duplicate Resource" functionality

### DIFF
--- a/backend/model/archival_object.rb
+++ b/backend/model/archival_object.rb
@@ -23,7 +23,7 @@ ArchivalObject.auto_generate(property: :ref_id,
                                  repo_id = RequestContext.get(:repo_id)
                                  resource = Resource.to_jsonmodel(JSONModel::JSONModel(:resource).id_for(json['resource']['ref']))
                                  # Duplicate resource core function adds ref_id-illegal characters to the ead id that
-                                 # must be stripped out 
+                                 # must be stripped out
                                  cleaned_eadid = resource['ead_id'].delete('[]').gsub(/\s+/, '')
                                  rule_template.result(binding())
                                # handling for caas_regenerate_ref_id set to false, including bulk update flow

--- a/backend/model/archival_object.rb
+++ b/backend/model/archival_object.rb
@@ -14,7 +14,7 @@ def generate_ref_id(resource, repo_id)
   end
 end
 
-rule_template = ERB.new("<%= resource['ead_id'] %>_ref<%= generate_ref_id(resource, repo_id) %>")
+rule_template = ERB.new("<%= cleaned_eadid %>_ref<%= generate_ref_id(resource, repo_id) %>")
 
 ArchivalObject.auto_generate(property: :ref_id,
                              generator: proc do |json|
@@ -22,6 +22,9 @@ ArchivalObject.auto_generate(property: :ref_id,
                                if json['ref_id'].nil? || json['caas_regenerate_ref_id']
                                  repo_id = RequestContext.get(:repo_id)
                                  resource = Resource.to_jsonmodel(JSONModel::JSONModel(:resource).id_for(json['resource']['ref']))
+                                 # Duplicate resource core function adds ref_id-illegal characters to the ead id that
+                                 # must be stripped out 
+                                 cleaned_eadid = resource['ead_id'].delete('[]').gsub(/\s+/, '')
                                  rule_template.result(binding())
                                # handling for caas_regenerate_ref_id set to false, including bulk update flow
                                elsif json['caas_regenerate_ref_id'] === false && json['uri']

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -156,4 +156,37 @@ describe 'ArchivalObject model' do
       end
     end
   end
+
+  context 'when the resource record is being duplicated' do
+    let(:resource) { create_resource({ ead_id: '[Duplicated] my.eadid' }) }
+    let(:response) { instance_double(Net::HTTPResponse) }
+    let(:caas_next_refid) do
+      JSONModel(:caas_next_refid).from_hash({ resource_id: resource.id,
+                                              next_refid: 11 })
+    end
+
+    before do
+      allow(Net::HTTP).to receive(:start).and_return(response)
+      allow(response).to receive(:body).and_return(caas_next_refid.to_json)
+    end
+
+    describe '#auto_generate' do
+      context 'when the archival object is new' do
+        let(:archival_object) do
+          create_archival_object({ ref_id: nil,
+                                    resource: { ref: "/repositories/2/resources/#{resource.id}" } })
+        end
+
+        it 'calls the caas_next_refid endpoint' do
+          archival_object
+
+          expect(Net::HTTP).to have_received(:start)
+        end
+
+        it 'auto generates the ref_id with a cleaned ead_id' do
+          expect(archival_object.ref_id).to eq('Duplicatedmy.eadid_ref10')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #52

## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
The new "Duplicate Resource" functionality added to core ArchivesSpace in versions 4.x and onward will generate resource records with EAD ID's that look like `[Duplicated] my_exsiting.eadid`.  While this is valid for an ead_id in ArchivesSpace, since we use these ead ids as the starting point for our archival object ref_ids, this core change introduces illegal characters into the ref_ids that our plugin attempts to create.  The autogeneration function used for archival object models has been updated to strip these new [Duplicated] ids of the illegal square brackets and white space so that valid ref_ids can be generated during the resource duplication process.

As delivered, this MVP approach will contain two idiosyncracies:
- First, since the background job that drives the "duplicate resource" functionality won't have finished creating the resource record prior to attempting to iterate through duplicating the archival objects, our `caas_next_refid` plugin endpoint will always fails to resolve the new/duplicated resource, and, as such, all generated ref_ids will be based on the fallback date/time string.
- Second, since the resource duplication process will also copy over the existing resource's `caas_next_refid`, when/if an admin user goes to regenerate the ref ids in the future, those regenerated ref_ids will start incrementing at the last held ref_id value of the original/duplicated source resource.

While of note and worth discussion, I concluded these were fine tradeoffs since any duplicated resource record is going to have to go through some cleanup processes after duplication.  We know, for example, that unit's will not want to continue to use resource records with EAD IDs like `[Duplicated] NMAI.AC.001`.  Once the new/desired EAD ID is entered into the new/duplicated resource, ref_id's will need to be regenerated anyway.  This makes the date/time string pattern only temporary and not a blocker.

Similarly, while we assign meaning to the ref_id increment, it really should not matter what number we start at.  If this edge case proves to be a problem for SI users, or if we feel strongly about it starting at 1, then I would rather proceed with a PR into core ASpace to allow an optional "json data not to duplicate" functionality to be added via a plugin, by which we could ensure that the existing caas_aspace_refid data is dropped from the duplication.  Doing so from our plugin along would probably prove very burdensome, and be prone to maintenance headaches in the future as this duplication functionality is iterated on by the ASpace team.

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->
#52 

## Testing
<!--- Please describe, in detail, how you tested your changes. -->
New test added, tested manually.

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
